### PR TITLE
Make the extension configurable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem 'rails', '>0.a'
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
+# Use official "analytics-ruby" gem as Segment backend for testing parts of your engine
+gem 'analytics-ruby', '~> 2.2.8', require: 'segment/analytics'
+
 case ENV['DB']
 when 'mysql'
   gem 'mysql2'

--- a/lib/solidus_segment.rb
+++ b/lib/solidus_segment.rb
@@ -5,3 +5,4 @@ require 'solidus_support'
 
 require 'solidus_segment/version'
 require 'solidus_segment/engine'
+require 'solidus_segment/configuration'

--- a/lib/solidus_segment/configuration.rb
+++ b/lib/solidus_segment/configuration.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module SolidusSegment
+  def self.configure
+    yield configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  class Configuration
+    attr_writer :segment_backend
+    attr_accessor :segment_write_key
+
+    class Error < NameError
+      def message
+        <<-MESSAGE
+          Please configure the Segment backend or install analytics-ruby
+          (https://github.com/segmentio/analytics-ruby) to use the default one.
+        MESSAGE
+      end
+    end
+
+    def segment_backend
+      @segment_backend ||= Segment::Analytics.new(write_key: segment_write_key)
+    rescue NameError
+      raise SolidusSegment::Configuration::Error
+    end
+  end
+end

--- a/spec/lib/solidus_segment/configuration_spec.rb
+++ b/spec/lib/solidus_segment/configuration_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidusSegment::Configuration do
+  it 'can be accessed by SolidusSegment::configuration' do
+    expect(SolidusSegment.configuration).to be_instance_of described_class
+  end
+
+  describe "#segment_backend" do
+    subject(:configuration) { described_class.new }
+
+    it "returns the configured backend" do
+      backend = instance_double('Backend::Analytics')
+      configuration.segment_backend = backend
+
+      expect(configuration.segment_backend).to eq(backend)
+    end
+
+    it "raises SolidusSegment::Configuration::Error when analytics-ruby gem is not present" do
+      hide_const('Segment::Analytics')
+
+      expect{ configuration.segment_backend }.to raise_error(SolidusSegment::Configuration::Error)
+    end
+
+    context "when analytics-ruby gem is present" do
+      it "returns an instance of Segment::Analytics" do
+        configuration.segment_write_key = '123'
+        expect(configuration.segment_backend).to be_a(Segment::Analytics)
+      end
+
+      it "instantiaes Segment::Analytics with the configured segment_write_key" do
+        configuration.segment_write_key = '123'
+        allow(Segment::Analytics).to receive(:new)
+
+        configuration.segment_backend
+
+        expect(Segment::Analytics).to have_received(:new).with(write_key: '123')
+      end
+
+      it "raises an error when the write key is missing " do
+        expect{ configuration.segment_backend }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to set the Segment backend to use.
If the segment_backend configuration isn't specified and the Segment the `analytics-ruby` gem is present it will instantiate a new `Segment::Analytics` class using the segment_write_key configuration attribute.

Ex.
```ruby
SolidusSegment.configure do |config|
  config.segment_write_key = '123456'
end
```