### PR TITLE
Allow to identify with custom arguments

### DIFF
--- a/lib/solidus_segment/analytics.rb
+++ b/lib/solidus_segment/analytics.rb
@@ -14,8 +14,8 @@ module SolidusSegment
       @backend = backend
     end
 
-    def identify
-      backend.identify(identify_params)
+    def identify(**args)
+      backend.identify(common_params.merge(traits: traits).merge(args).compact)
     end
 
     def track(event, **args)
@@ -37,10 +37,6 @@ module SolidusSegment
         anonymous_id: anonymous_id,
         integrations: integrations
       }
-    end
-
-    def identify_params
-      { traits: traits }.merge(common_params).compact
     end
 
     def traits

--- a/spec/lib/solidus_segment/analytics_spec.rb
+++ b/spec/lib/solidus_segment/analytics_spec.rb
@@ -70,6 +70,22 @@ RSpec.describe SolidusSegment::Analytics do
         integrations: { "Google Analytics": { clientId: "123" } }
       )
     end
+
+    it "merges common parameters with the given arguments" do
+      backend = instance_double("Backend::Analytics")
+      allow(backend).to receive(:identify)
+
+      described_class.new(user: user, backend: backend).identify(
+        traits: { email: "email@example.com" },
+        integrations: { custom: "custom_param" }
+      )
+
+      expect(backend).to have_received(:identify).with(
+        user_id: user.id,
+        traits: { email: "email@example.com" },
+        integrations: { custom: "custom_param" }
+      )
+    end
   end
 
   describe "#track_order_completed" do


### PR DESCRIPTION
Adds arguments to the `SolidusSegment::Analytics#identify` method, if given the arguments will be merged with the common parameters.