### PR TITLE
Change user agent key from snake case to camel case

### DIFF
--- a/lib/solidus_segment/serializers/common_serializer.rb
+++ b/lib/solidus_segment/serializers/common_serializer.rb
@@ -32,7 +32,7 @@ module SolidusSegment
       end
 
       def common_context
-        { user_agent: request.user_agent, ip: request.remote_addr }
+        { userAgent: request.user_agent, ip: request.remote_addr }
       end
 
       def anonymous_id

--- a/spec/lib/solidus_segment/serializers/common_serializer_spec.rb
+++ b/spec/lib/solidus_segment/serializers/common_serializer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SolidusSegment::Serializers::CommonSerializer do
           }
         },
         context: {
-          user_agent: "Rails Testing",
+          userAgent: "Rails Testing",
           ip: "0.0.0.0"
         }
       )


### PR DESCRIPTION
Looking at the documentation https://segment.com/docs/connections/spec/common/#context I've found that we send the user agent with the wrong key, it must be camel case.